### PR TITLE
ナビバーのレスポンシブ対応

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -114,12 +114,15 @@
 
       <v-spacer></v-spacer>
 
-      <v-toolbar-items>
-        <v-btn text to="/">Home</v-btn>
-        <v-btn text to="/about">About</v-btn>
-        <v-btn text to="/works">Works</v-btn>
-        <v-btn text to="/contact">Contact</v-btn>
-      </v-toolbar-items>
+      <div class="hide_mobile">
+        <v-toolbar-items>
+          <v-btn text to="/">Home</v-btn>
+          <v-btn text to="/about">About</v-btn>
+          <v-btn text to="/works">Works</v-btn>
+          <v-btn text to="/contact">Contact</v-btn>
+        </v-toolbar-items>
+      </div>
+
     </v-app-bar>
     <!-- ナビバー終了 -->
 
@@ -230,4 +233,12 @@ a {
     font-weight: bold;
     color: #2c3e50;
   }
+.hide_mobile {
+  height: 100% !important;
+}
+@media screen and (max-width:720px){
+  .hide_mobile {
+    display: none;
+  }
+}
 </style>

--- a/src/components/about.vue
+++ b/src/components/about.vue
@@ -44,10 +44,6 @@
 
     </div>
 
-
-      <!-- ランダムに画像を配置するfanctionの実装 画像は6枚ほど？ toolchipの設定 -->
-    <!-- <image-view/> -->
-
   </div>
 </template>
 

--- a/src/components/contact.vue
+++ b/src/components/contact.vue
@@ -89,7 +89,7 @@ export default {
     -2px  0px 4px #072142,
     0px  -2px 4px #072142;
   position: relative;
-  z-index: 20;
+  z-index: 2;
 }
 .contact-view {
   position: relative;


### PR DESCRIPTION
What
・表示画面のサイズによってナビバーの表示項目の変更
　・モバイルサイズではナビアイテムを非表示に設定

・Contactページのタイトルのz-indexの変更

Why
・ナビバーの表示崩れを解消するため
・コンタクトページでサブメニューを展開した際に、タイトルの文字がメニューバーに被って表示されたため